### PR TITLE
Adapt to new signature of ve.ui.Sequence

### DIFF
--- a/veAutocorrect.js
+++ b/veAutocorrect.js
@@ -19,7 +19,7 @@
 (function (mw) {
 	"use strict";
 
-	var version = '2.2.0';
+	var version = '2.2.1';
 
 	/**
 	 * Helpers for defining replacements.
@@ -245,7 +245,7 @@
 		ve.init.target.getSurface().commands.push(name);
 		//create and register the sequence
 		ve.ui.sequenceRegistry.register(
-			new ReSequence(/*sequence*/ name, /*command*/ name, from, 0, true)
+			new ReSequence(/*sequence*/ name, /*command*/ name, from, 0, { setSelection: true })
 		);
 	}
 	var autoCorrectCommandCount = 0;


### PR DESCRIPTION
ve.ui.Sequence now expects that `config` is passed as an object, instead of positional parameters. Support for the latter has been dropped in May after a transition period. Usage of the old signature caused the patterns not to disappear when attempting to replace them.

https://gerrit.wikimedia.org/r/plugins/gitiles/VisualEditor/VisualEditor/+/a0a0825cf0095dadc6206abd4591184d5d7e0325%5E%21/src/ui/ve.ui.Sequence.js